### PR TITLE
Add JSON validation test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test"
   },
   "dependencies": {
     "@ai-sdk/openai": "latest",

--- a/reactflow_dependencies.json
+++ b/reactflow_dependencies.json
@@ -11,5 +11,6 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-slot": "^1.0.2",
-    "class-variance-authority": "^0.7.0",
-    "c
+    "class-variance-authority": "^0.7.0"
+  }
+}

--- a/tests/reactflow_dependencies.test.js
+++ b/tests/reactflow_dependencies.test.js
@@ -1,0 +1,10 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+test('reactflow_dependencies.json parses as valid JSON', () => {
+  const filePath = path.join(__dirname, '..', 'reactflow_dependencies.json');
+  const content = fs.readFileSync(filePath, 'utf8');
+  assert.doesNotThrow(() => JSON.parse(content));
+});


### PR DESCRIPTION
## Summary
- add Node.js test to check `reactflow_dependencies.json` parses
- enable `npm test` to run Node.js tests
- fix incomplete JSON in `reactflow_dependencies.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842dfdb07f0833199f51ea117238679